### PR TITLE
Entities

### DIFF
--- a/training-interface/src/components/Entities/Entities.js
+++ b/training-interface/src/components/Entities/Entities.js
@@ -3,10 +3,12 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import InputGroup from 'react-bootstrap/InputGroup'
 import FormControl from 'react-bootstrap/FormControl'
+import Button from 'react-bootstrap/Button'
 import Jumbotron from 'react-bootstrap/Jumbotron'
-import Form from 'react-bootstrap/Form'
 import Container from 'react-bootstrap/Container'
 import '../../App.css';
+
+const axios = require('axios').default;
 
 class Entities extends Component {
   constructor(props) {
@@ -14,23 +16,55 @@ class Entities extends Component {
     this.state = {
       Entity: '',
       Value: '',
-      Synonyms: ''
+      Synonyms: '',
+      tableArray: null,
     };
   }
 
-  generateTable() {
-    let arr = [];
+  componentDidMount() {
+    this.generateTable();
+  }
 
-    for (var i = 0; i < x.length; i++) {
-      var element = (
-        <div class="custom-control custom-checkbox">
-          <input type="checkbox" class="custom-control-input" id={x[i]}></input>
-          <label class="custom-control-label" for={x[i]}>{x[i]}</label>
-        </div>
-      )
-      arr.push(element);
-    }
-    return arr;
+
+  getData() {
+    var getDatas = axios.get('http://localhost:5000/api/entities')
+      .then((response) => {
+        console.log(response.data);
+        return response.data;
+      })
+      .catch(function (error) {
+        console.log(error);
+        return error;
+
+      });
+    return getDatas;
+  }
+
+  // Similar to intents, if I was to work more on this there would be a table component to prevent dupe
+  generateTable() {
+    this.getData()
+      .then((response) => {
+        console.log("response", response);
+        var x = response;
+        var arr = [];
+
+        for (var i = 0; i < x.length; i++) {
+          var element = (
+            <div>
+              <div className="custom-control custom-checkbox">
+                <input type="checkbox" className="custom-control-input" id={x[i]._id} onClick={this.handleCheck} name={x[i].name}></input>
+                <label className="custom-control-label" for={x[i]._id}> {x[i].name} </label>
+              </div>
+            </div>
+          )
+          arr.push(element);
+        }
+        this.setState({ tableArray: arr })
+      })
+
+      .catch(function (error) {
+        console.log(error);
+      });
   }
 
 
@@ -39,7 +73,6 @@ class Entities extends Component {
   //run 'json-server db.json -w -p 8000' in /server directory
   //go 'http://localhost:8000/entities'
   render() {
-    //var list = this.generateTable();
 
     return (
       <div>
@@ -61,7 +94,7 @@ class Entities extends Component {
             <Container fluid className="tile-glow">
               <h4> Entities: </h4>
               <div style={{ height: "70%", overflow: "auto", borderStyle: "solid", borderWeight: "0.1px", borderColor: "#13beb1", padding: "3px" }}>
-                {list}
+                {this.state.tableArray}
               </div>
               <button type="#" className="btn btn-primary">Remove</button>
             </Container>

--- a/training-interface/src/components/Entities/Entities.js
+++ b/training-interface/src/components/Entities/Entities.js
@@ -18,12 +18,10 @@ class Entities extends Component {
     };
   }
 
-  generateTable(){
-    let x = ["time", "scheduled_flight", "day", "flight", "hour", "passenger", "user", "delay", "ticket", "boarding", "departure", "arrival", "delay", "complaint", "these", "are", "just", "test","test",
-    "test","test","test"];
+  generateTable() {
     let arr = [];
-    
-    for(var i=0; i<x.length; i++) {
+
+    for (var i = 0; i < x.length; i++) {
       var element = (
         <div class="custom-control custom-checkbox">
           <input type="checkbox" class="custom-control-input" id={x[i]}></input>
@@ -31,50 +29,8 @@ class Entities extends Component {
         </div>
       )
       arr.push(element);
-  }
-  return arr;
-}
-
-
-  handleValueChange(field, value, type='string') {
-    if(type === 'number'){
-      value = + value;
     }
-    this.setState({
-      [field]: value
-    });
-    console.log(value);
-  }
-
-
-  handleSubmit (e) {
-    e.preventDefault();
-    const {Entity,Value,Synonyms} = this.state;
-    fetch('http://localhost:8000/entities', {
-      method: 'post',
-      body: JSON.stringify({
-        Entity,
-        Value,
-        Synonyms
-      }),
-        headers: {
-       'Content-Type': 'application/json'
-        }
-    })
-    .then((res) => res.json())
-    .then((res) => {
-      if (res.id) {
-        alert('add successfully');
-        this.setState({
-          Entity: '',
-          Value: '',
-          Synonyms: ''
-        });
-      } else {
-        alert('fail to add');
-      }
-    })
-    .catch((err) => console.error(err));
+    return arr;
   }
 
 
@@ -82,62 +38,44 @@ class Entities extends Component {
   //The form information is supposed to see by
   //run 'json-server db.json -w -p 8000' in /server directory
   //go 'http://localhost:8000/entities'
-  render () {
-    var list = this.generateTable();
-    
+  render() {
+    //var list = this.generateTable();
+
     return (
       <div>
-      <InputGroup style = {{padding:"20px"}}>
-        <InputGroup.Prepend>
-          <InputGroup.Text id="btnGroupAddon">@</InputGroup.Text>
-        </InputGroup.Prepend>
+        <InputGroup style={{ padding: "20px" }}>
+          <InputGroup.Prepend>
+            <InputGroup.Text id="btnGroupAddon">@</InputGroup.Text>
+          </InputGroup.Prepend>
           <FormControl
             type="text"
             placeholder="Search for an entity"
             aria-label="Input group example"
             aria-describedby="btnGroupAddon"
           />
-      </InputGroup>
-      
-      
-      <Row style = {{padding:"20px"}}>
-        <Col lg={5}>
-          <Container fluid className="tile-glow">
-            <h4> Entities: </h4>
-            <div style ={{height:"70%", overflow:"auto", borderStyle: "solid", borderWeight:"0.1px", borderColor: "#13beb1", padding:"3px"}}>
-              {list}
-            </div>
-            <button type="#" className="btn btn-primary">Remove</button>
-          </Container>
-        </Col>
-        
-        <Col lg={7}>
-        {/* Ruxin I have just converted your form to React Bootstrap (makes styling easier)
+        </InputGroup>
+
+
+        <Row style={{ padding: "20px" }}>
+          <Col lg={5}>
+            <Container fluid className="tile-glow">
+              <h4> Entities: </h4>
+              <div style={{ height: "70%", overflow: "auto", borderStyle: "solid", borderWeight: "0.1px", borderColor: "#13beb1", padding: "3px" }}>
+                {list}
+              </div>
+              <button type="#" className="btn btn-primary">Remove</button>
+            </Container>
+          </Col>
+
+          <Col lg={7}>
+            {/* Ruxin I have just converted your form to React Bootstrap (makes styling easier)
           https://react-bootstrap.netlify.com/components/forms/#forms */}
-        <Jumbotron fluid style = {{width:"50%" ,padding:"20px"}}>
-          <Form>
-          <h4 style ={{paddingBottom: "6px"}}>Create New Entity</h4>
-
-            <Form.Group controlId="Entity">
-              <Form.Label>Entity</Form.Label>
-              <Form.Control type="text" placeholder="Enter an entity" />
-            </Form.Group>
-
-            <Form.Group controlId="Value">
-              <Form.Label>Value</Form.Label>
-              <Form.Control type="text" placeholder="Value" />
-            </Form.Group>
-
-            <Form.Group controlId="Synonyms">
-              <Form.Label>Synonyms</Form.Label>
-              <Form.Control type="text" placeholder="Synonyms" />
-            </Form.Group>
-            <button type="submit" className="btn btn-primary">Add</button>
-          </Form>
-        </Jumbotron>
-        </Col>
-      </Row>
-    </div>
+            <Jumbotron fluid style={{ width: "50%", padding: "20px" }}>
+              {/*Form*/}
+            </Jumbotron>
+          </Col>
+        </Row>
+      </div>
 
     )
   }

--- a/training-interface/src/components/Entities/Entities.js
+++ b/training-interface/src/components/Entities/Entities.js
@@ -14,9 +14,6 @@ class Entities extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      Entity: '',
-      Value: '',
-      Synonyms: '',
       tableArray: null,
     };
   }

--- a/training-interface/src/components/Entities/Entities.js
+++ b/training-interface/src/components/Entities/Entities.js
@@ -6,6 +6,7 @@ import FormControl from 'react-bootstrap/FormControl'
 import Button from 'react-bootstrap/Button'
 import Jumbotron from 'react-bootstrap/Jumbotron'
 import Container from 'react-bootstrap/Container'
+import EntityForm from './components/EntityForm'
 import '../../App.css';
 
 const axios = require('axios').default;
@@ -101,7 +102,7 @@ class Entities extends Component {
             {/* Ruxin I have just converted your form to React Bootstrap (makes styling easier)
           https://react-bootstrap.netlify.com/components/forms/#forms */}
             <Jumbotron fluid style={{ width: "50%", padding: "20px" }}>
-              {/*Form*/}
+            <EntityForm edit={this.state.edit} editState={this.state.edit} />
             </Jumbotron>
           </Col>
         </Row>

--- a/training-interface/src/components/Entities/components/EntityForm.js
+++ b/training-interface/src/components/Entities/components/EntityForm.js
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import IntentInputs from './SynonymInput.js';
+import Form from 'react-bootstrap/Form'
+import Row from 'react-bootstrap/Row'
+import Col from 'react-bootstrap/Col'
+import Button from 'react-bootstrap/Button'
+const axios = require('axios').default;
+
+const EntityForm = ({ edit, editState }) => {
+
+    const [nameState, setNameState] = useState({
+        name: '',
+    });
+
+    const handleNameChange = (e) => setNameState({
+        ...nameState,
+        name: e.target.value,
+    });
+
+    const blankIntent = { name: '', expression: [] };
+    const [entityState, setexpressionState] = useState([
+        { ...blankIntent },
+    ]);
+
+    const addEntity = () => {
+        setexpressionState([...entityState, { ...blankIntent }]);
+    };
+
+    const handleEntityChange = (e) => {
+        const updatedEntities = [...entityState];
+        updatedEntities[e.target.dataset.idx] = e.target.value;
+        setexpressionState(updatedEntities);
+    };
+
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        axios.post('http://localhost:5000/api/intents', {
+            name: nameState.name,
+            expressions: entityState,
+        })
+            .then(function (response) {
+                console.log(response);
+                window.location.reload(true);
+            })
+            .catch(function (error) {
+                console.log(error);
+            });
+    }
+
+    const handleCancel = (e) => {
+        e.preventDefault();
+        window.location.reload(true);
+    }
+
+
+    return (
+        <Form onSubmit={handleSubmit}>
+
+
+
+            <Form.Group controlId="Intent">
+                <Form.Label>Entity name</Form.Label>
+                <Form.Control type="text" placeholder="Enter entity name"
+                    name="entity"
+                    onChange={handleNameChange}
+                />
+            </Form.Group>
+
+
+
+            <Form.Group controlId="Intent.Description">
+            </Form.Group>
+            {
+                entityState.map((val, idx) => (
+                    <IntentInputs
+                        key={`enti-${idx}`}
+                        idx={idx}
+                        entityState={entityState}
+                        handleEntityChange={handleEntityChange}
+                    />
+                ))
+            }
+            <Row>
+                <Col><button onClick={handleSubmit} type="submit" className="btn btn-primary">Add</button></Col>
+                <Col> <Button onClick={handleCancel} variant="outline-danger" style={{ float: "right", margin: "30px" }}>Cancel</Button></Col>
+            </Row>
+            <p>Add another reference<Button variant="secondary" size="sm" style={{ marginLeft: "5px", lineHeight: "1.3", borderRadius: "15px" }} value="Add another expression"
+                        onClick={addEntity}>
+                        +
+              </Button></p>
+        </Form>
+
+    );
+};
+
+export default EntityForm;

--- a/training-interface/src/components/Entities/components/EntityForm.js
+++ b/training-interface/src/components/Entities/components/EntityForm.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import SynonymInput from './SynonymInput.js';
+import SynonymInputs from './SynonymInput.js';
 import Form from 'react-bootstrap/Form'
 import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
@@ -18,28 +18,30 @@ const EntityForm = () => {
         name: e.target.value,
     });
 
-    const blankIntent = { reference: '', synonym: [] };
-    const [entityState, setexpressionState] = useState([
+    const blankIntent = { synonym_reference: '', list: [] };
+    const [entityState, setEntityState] = useState([
         { ...blankIntent },
     ]);
 
     const addReference = () => {
-        setexpressionState([...entityState, { ...blankIntent }]);
+        setEntityState([...entityState, { ...blankIntent }]);
     };
 
     const handleReferenceChange = (e) => {
         const updatedEntities = [...entityState];
-        updatedEntities[e.target.dataset.idx]["reference"] = e.target.value;
-        setexpressionState(updatedEntities);
+        updatedEntities[e.target.dataset.idx]["synonym_reference"] = e.target.value;
+        setEntityState(updatedEntities);
     };
 
 
     const handleSubmit = (e) => {
-      /*  e.preventDefault();
-        foreach
+    console.log(entityState);
+    console.log(nameState);
+     e.preventDefault();
+     console.log("TRYING")
         axios.post('http://localhost:5000/api/entities', {
-            reference: nameState,
-            expressions: entityState,
+            name: nameState.name,
+            synonyms: entityState,
         })
             .then(function (response) {
                 console.log(response);
@@ -47,13 +49,14 @@ const EntityForm = () => {
             })
             .catch(function (error) {
                 console.log(error);
-            });*/
-    }
+            });
+ 
+    };
 
     const handleCancel = (e) => {
         e.preventDefault();
         window.location.reload(true);
-    }
+    };
 
 
     return (
@@ -74,7 +77,7 @@ const EntityForm = () => {
                             idx={idx}
                             entityState={entityState}
                             handleReferenceChange={handleReferenceChange}
-                            setexpressionState={setexpressionState}
+                            setEntityState={setEntityState}
                             entityState={entityState}
                         />
                     ))
@@ -82,7 +85,7 @@ const EntityForm = () => {
             </div>
             <Row>
                 <Col><button onClick={handleSubmit} type="submit" className="btn btn-primary">Add</button></Col>
-                <Col> <Button onClick={handleCancel} variant="outline-danger" style={{ float: "right", margin: "30px" }}>Cancel</Button></Col>
+                <Col> <Button onClick={handleSubmit} variant="outline-danger" style={{ float: "right", margin: "30px" }}>Cancel</Button></Col>
             </Row>
             <p>Add another reference<Button variant="secondary" size="sm" style={{ marginLeft: "5px", lineHeight: "0.9", borderRadius: "10px" }}
                 onClick={addReference}>

--- a/training-interface/src/components/Entities/components/EntityForm.js
+++ b/training-interface/src/components/Entities/components/EntityForm.js
@@ -69,8 +69,7 @@ const EntityForm = ({ edit, editState }) => {
 
 
 
-            <Form.Group controlId="Intent.Description">
-            </Form.Group>
+            
             {
                 entityState.map((val, idx) => (
                     <IntentInputs
@@ -85,7 +84,7 @@ const EntityForm = ({ edit, editState }) => {
                 <Col><button onClick={handleSubmit} type="submit" className="btn btn-primary">Add</button></Col>
                 <Col> <Button onClick={handleCancel} variant="outline-danger" style={{ float: "right", margin: "30px" }}>Cancel</Button></Col>
             </Row>
-            <p>Add another reference<Button variant="secondary" size="sm" style={{ marginLeft: "5px", lineHeight: "1.3", borderRadius: "15px" }} value="Add another expression"
+            <p>Add another reference<Button variant="secondary" size="sm" style={{ marginLeft: "5px", lineHeight: "0.9", borderRadius: "10px" }}
                         onClick={addEntity}>
                         +
               </Button></p>

--- a/training-interface/src/components/Entities/components/EntityForm.js
+++ b/training-interface/src/components/Entities/components/EntityForm.js
@@ -56,9 +56,6 @@ const EntityForm = ({ edit, editState }) => {
 
     return (
         <Form onSubmit={handleSubmit}>
-
-
-
             <Form.Group controlId="Intent">
                 <Form.Label>Entity name</Form.Label>
                 <Form.Control type="text" placeholder="Enter entity name"
@@ -67,9 +64,7 @@ const EntityForm = ({ edit, editState }) => {
                 />
             </Form.Group>
 
-
-
-            
+            <div style={{overflow:"auto", maxHeight: "300px",margin:"2px", padding: "5px" }}>
             {
                 entityState.map((val, idx) => (
                     <IntentInputs
@@ -80,6 +75,7 @@ const EntityForm = ({ edit, editState }) => {
                     />
                 ))
             }
+            </div>
             <Row>
                 <Col><button onClick={handleSubmit} type="submit" className="btn btn-primary">Add</button></Col>
                 <Col> <Button onClick={handleCancel} variant="outline-danger" style={{ float: "right", margin: "30px" }}>Cancel</Button></Col>

--- a/training-interface/src/components/Entities/components/EntityForm.js
+++ b/training-interface/src/components/Entities/components/EntityForm.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
-import IntentInputs from './SynonymInput.js';
+import SynonymInput from './SynonymInput.js';
 import Form from 'react-bootstrap/Form'
 import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
 import Button from 'react-bootstrap/Button'
+
 const axios = require('axios').default;
 
-const EntityForm = ({ edit, editState }) => {
+const EntityForm = () => {
 
     const [nameState, setNameState] = useState({
         name: '',
@@ -17,26 +18,27 @@ const EntityForm = ({ edit, editState }) => {
         name: e.target.value,
     });
 
-    const blankIntent = { name: '', expression: [] };
+    const blankIntent = { reference: '', synonym: [] };
     const [entityState, setexpressionState] = useState([
         { ...blankIntent },
     ]);
 
-    const addEntity = () => {
+    const addReference = () => {
         setexpressionState([...entityState, { ...blankIntent }]);
     };
 
-    const handleEntityChange = (e) => {
+    const handleReferenceChange = (e) => {
         const updatedEntities = [...entityState];
-        updatedEntities[e.target.dataset.idx] = e.target.value;
+        updatedEntities[e.target.dataset.idx]["reference"] = e.target.value;
         setexpressionState(updatedEntities);
     };
 
 
     const handleSubmit = (e) => {
-        e.preventDefault();
-        axios.post('http://localhost:5000/api/intents', {
-            name: nameState.name,
+      /*  e.preventDefault();
+        foreach
+        axios.post('http://localhost:5000/api/entities', {
+            reference: nameState,
             expressions: entityState,
         })
             .then(function (response) {
@@ -45,7 +47,7 @@ const EntityForm = ({ edit, editState }) => {
             })
             .catch(function (error) {
                 console.log(error);
-            });
+            });*/
     }
 
     const handleCancel = (e) => {
@@ -57,32 +59,34 @@ const EntityForm = ({ edit, editState }) => {
     return (
         <Form onSubmit={handleSubmit}>
             <Form.Group controlId="Intent">
-                <Form.Label>Entity name</Form.Label>
-                <Form.Control type="text" placeholder="Enter entity name"
-                    name="entity"
+                <Form.Label>Entity reference</Form.Label>
+                <Form.Control type="text" placeholder="Enter entity reference"
+                    reference="entity"
                     onChange={handleNameChange}
                 />
             </Form.Group>
 
-            <div style={{overflow:"auto", maxHeight: "300px",margin:"2px", padding: "5px" }}>
-            {
-                entityState.map((val, idx) => (
-                    <IntentInputs
-                        key={`enti-${idx}`}
-                        idx={idx}
-                        entityState={entityState}
-                        handleEntityChange={handleEntityChange}
-                    />
-                ))
-            }
+            <div style={{ overflow: "auto", maxHeight: "300px", margin: "2px", padding: "5px" }}>
+                {
+                    entityState.map((val, idx) => (
+                        <SynonymInputs
+                            key={`enti-${idx}`}
+                            idx={idx}
+                            entityState={entityState}
+                            handleReferenceChange={handleReferenceChange}
+                            setexpressionState={setexpressionState}
+                            entityState={entityState}
+                        />
+                    ))
+                }
             </div>
             <Row>
                 <Col><button onClick={handleSubmit} type="submit" className="btn btn-primary">Add</button></Col>
                 <Col> <Button onClick={handleCancel} variant="outline-danger" style={{ float: "right", margin: "30px" }}>Cancel</Button></Col>
             </Row>
             <p>Add another reference<Button variant="secondary" size="sm" style={{ marginLeft: "5px", lineHeight: "0.9", borderRadius: "10px" }}
-                        onClick={addEntity}>
-                        +
+                onClick={addReference}>
+                +
               </Button></p>
         </Form>
 

--- a/training-interface/src/components/Entities/components/SynonymInput.js
+++ b/training-interface/src/components/Entities/components/SynonymInput.js
@@ -24,7 +24,7 @@ const IntentInputs = ({ idx, entityState, handleEntityChange }) => {
 
 
     return (
-        <div key={`enti-${idx}`}>
+        <div key={`enti-${idx}`} style={{ margin: "2px", borderStyle: "dashed", borderWeight: "0.1px", borderColor: "#13beb1", padding: "5px" }}>
             <Form.Label>Reference
                 </Form.Label>
             <Form.Control type="text" placeholder={`Reference ${idx + 1}`}
@@ -35,15 +35,15 @@ const IntentInputs = ({ idx, entityState, handleEntityChange }) => {
                 value={entityState[idx].name}
                 onChange={handleEntityChange}
             />
-            
+
             <Form.Group controlId="Synonym.Description">
-                <Form.Label style = {{marginLeft:"10px", marginTop:"5px"}}>Synonyms
-                <Button variant="secondary" size="sm" style = { {marginLeft: "5px", lineHeight: "0.9", borderRadius: "10px"} } value="Add another expression"
+                <Form.Label style={{ marginLeft: "10px", marginTop: "5px" }}>Synonyms
+                <Button variant="secondary" size="sm" style={{ marginLeft: "5px", lineHeight: "0.9", borderRadius: "10px" }} value="Add another expression"
                         onClick={addList}>
                         +
               </Button></Form.Label>
             </Form.Group>
-            
+
             {
                 synonymState.map((val, idx) => (
                     <SynonymList

--- a/training-interface/src/components/Entities/components/SynonymInput.js
+++ b/training-interface/src/components/Entities/components/SynonymInput.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import Form from 'react-bootstrap/Form'
+import Button from 'react-bootstrap/Button'
+import SynonymList from './SynonymList.js';
+
+const IntentInputs = ({ idx, entityState, handleEntityChange }) => {
+    const entityId = `enti-${idx}`;
+
+    const blankSynonym = { name: '', expression: [] };
+    const [synonymState, setsynonymState] = useState([
+        { ...blankSynonym },
+    ]);
+
+    const addList = () => {
+        setsynonymState([...synonymState, { ...blankSynonym }]);
+    };
+
+    const handleSynonymChange = (e) => {
+        const updatedSynonym = [...synonymState];
+        updatedSynonym[e.target.dataset.idx] = e.target.value;
+        setsynonymState(updatedSynonym);
+    };
+
+
+    return (
+        <div key={`enti-${idx}`}>
+            <Form.Label>Reference
+                </Form.Label>
+            <Form.Control type="text" placeholder={`Reference ${idx + 1}`}
+                name={entityId}
+                data-idx={idx}
+                id={entityId}
+                className="entity"
+                value={entityState[idx].name}
+                onChange={handleEntityChange}
+            />
+            
+            <Form.Group controlId="Synonym.Description">
+                <Form.Label style = {{marginLeft:"10px", marginTop:"5px"}}>Synonyms
+                <Button variant="secondary" size="sm" style = { {marginLeft: "5px", lineHeight: "0.9", borderRadius: "10px"} } value="Add another expression"
+                        onClick={addList}>
+                        +
+              </Button></Form.Label>
+            </Form.Group>
+            
+            {
+                synonymState.map((val, idx) => (
+                    <SynonymList
+                        key={`syn-${idx}`}
+                        idx={idx}
+                        synonymState={synonymState}
+                        handleSynonymChange={handleSynonymChange}
+                    />
+                ))
+            }
+        </div>
+    );
+};
+
+IntentInputs.propTypes = {
+    idx: PropTypes.number,
+    entityState: PropTypes.array,
+    handleCatChange: PropTypes.func,
+};
+
+export default IntentInputs;

--- a/training-interface/src/components/Entities/components/SynonymInput.js
+++ b/training-interface/src/components/Entities/components/SynonymInput.js
@@ -4,11 +4,11 @@ import Form from 'react-bootstrap/Form'
 import Button from 'react-bootstrap/Button'
 import SynonymList from './SynonymList.js';
 
-const SynonymInputs = ({ idx, entityState, handleReferenceChange, setexpressionState}) => {
+const SynonymInputs = ({ idx, entityState, handleReferenceChange, setEntityState}) => {
     const entityId = `enti-${idx}`;
     const count = idx;
 
-    const blankSynonym = { name: '', synonym: [] };
+    const blankSynonym = { name: '', list: [] };
     const [synonymState, setsynonymState] = useState([
         { ...blankSynonym },
     ]);
@@ -20,8 +20,8 @@ const SynonymInputs = ({ idx, entityState, handleReferenceChange, setexpressionS
     const handleSynonymChange = (e) => {
         const updatedEntities = [...entityState];
         //This is the location to be edited.. index in reference array -> index in synonym array inside reference obj
-        updatedEntities[idx]["synonym"][e.target.dataset.idx] = e.target.value;
-       setexpressionState(updatedEntities);
+        updatedEntities[idx]["list"][e.target.dataset.idx] = e.target.value;
+       setEntityState(updatedEntities);
     };
 
 

--- a/training-interface/src/components/Entities/components/SynonymInput.js
+++ b/training-interface/src/components/Entities/components/SynonymInput.js
@@ -4,10 +4,11 @@ import Form from 'react-bootstrap/Form'
 import Button from 'react-bootstrap/Button'
 import SynonymList from './SynonymList.js';
 
-const IntentInputs = ({ idx, entityState, handleEntityChange }) => {
+const SynonymInputs = ({ idx, entityState, handleReferenceChange, setexpressionState}) => {
     const entityId = `enti-${idx}`;
+    const count = idx;
 
-    const blankSynonym = { name: '', expression: [] };
+    const blankSynonym = { name: '', synonym: [] };
     const [synonymState, setsynonymState] = useState([
         { ...blankSynonym },
     ]);
@@ -17,28 +18,28 @@ const IntentInputs = ({ idx, entityState, handleEntityChange }) => {
     };
 
     const handleSynonymChange = (e) => {
-        const updatedSynonym = [...synonymState];
-        updatedSynonym[e.target.dataset.idx] = e.target.value;
-        setsynonymState(updatedSynonym);
+        const updatedEntities = [...entityState];
+        //This is the location to be edited.. index in reference array -> index in synonym array inside reference obj
+        updatedEntities[idx]["synonym"][e.target.dataset.idx] = e.target.value;
+       setexpressionState(updatedEntities);
     };
 
 
     return (
         <div key={`enti-${idx}`} style={{ margin: "2px", borderStyle: "dashed", borderWeight: "0.1px", borderColor: "#13beb1", padding: "5px" }}>
-            <Form.Label>Reference
-                </Form.Label>
+            <Form.Label>Reference</Form.Label>
             <Form.Control type="text" placeholder={`Reference ${idx + 1}`}
                 name={entityId}
                 data-idx={idx}
                 id={entityId}
                 className="entity"
                 value={entityState[idx].name}
-                onChange={handleEntityChange}
+                onChange={handleReferenceChange}
             />
 
             <Form.Group controlId="Synonym.Description">
                 <Form.Label style={{ marginLeft: "10px", marginTop: "5px" }}>Synonyms
-                <Button variant="secondary" size="sm" style={{ marginLeft: "5px", lineHeight: "0.9", borderRadius: "10px" }} value="Add another expression"
+                <Button variant="secondary" size="sm" style={{ marginLeft: "5px", lineHeight: "0.9", borderRadius: "10px" }} value="Add another synonym"
                         onClick={addList}>
                         +
               </Button></Form.Label>
@@ -48,8 +49,9 @@ const IntentInputs = ({ idx, entityState, handleEntityChange }) => {
                 synonymState.map((val, idx) => (
                     <SynonymList
                         key={`syn-${idx}`}
+                        entityState={entityState}
                         idx={idx}
-                        synonymState={synonymState}
+                        count={count}
                         handleSynonymChange={handleSynonymChange}
                     />
                 ))
@@ -58,10 +60,10 @@ const IntentInputs = ({ idx, entityState, handleEntityChange }) => {
     );
 };
 
-IntentInputs.propTypes = {
+SynonymInputs.propTypes = {
     idx: PropTypes.number,
     entityState: PropTypes.array,
     handleCatChange: PropTypes.func,
 };
 
-export default IntentInputs;
+export default SynonymInputs;

--- a/training-interface/src/components/Entities/components/SynonymList.js
+++ b/training-interface/src/components/Entities/components/SynonymList.js
@@ -1,21 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Form from 'react-bootstrap/Form'
 
-const SynonymList = ({ idx, synonymState, handleSynonymChange }) => {
+const SynonymList = ({ idx, entityState, count, handleSynonymChange }) => {
     const synonymId = `syn-${idx}`;
-
 
 
     return (
         <div style ={{marginLeft:"10px"}} key={`exp-${idx}`} >
             
-            <Form.Control type="text" placeholder={`Synonym ${idx + 1}`}
-                name={synonymId}
+            <input type="text" placeholder={`Synonym ${idx + 1}`}
+                name={count}
                 data-idx={idx}
                 id={synonymId}
-                className="entity"
-                value={synonymState[idx].synonymId}
+                className={count}
+                value={entityState[count].synonym[idx]}
                 onChange={handleSynonymChange}
             />
         </div>

--- a/training-interface/src/components/Entities/components/SynonymList.js
+++ b/training-interface/src/components/Entities/components/SynonymList.js
@@ -13,7 +13,7 @@ const SynonymList = ({ idx, entityState, count, handleSynonymChange }) => {
                 data-idx={idx}
                 id={synonymId}
                 className={count}
-                value={entityState[count].synonym[idx]}
+                value={entityState[count].list[idx]}
                 onChange={handleSynonymChange}
             />
         </div>

--- a/training-interface/src/components/Entities/components/SynonymList.js
+++ b/training-interface/src/components/Entities/components/SynonymList.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Form from 'react-bootstrap/Form'
+
+const SynonymList = ({ idx, synonymState, handleSynonymChange }) => {
+    const synonymId = `syn-${idx}`;
+
+
+
+    return (
+        <div style ={{marginLeft:"10px"}} key={`exp-${idx}`} >
+            
+            <Form.Control type="text" placeholder={`Synonym ${idx + 1}`}
+                name={synonymId}
+                data-idx={idx}
+                id={synonymId}
+                className="entity"
+                value={synonymState[idx].synonymId}
+                onChange={handleSynonymChange}
+            />
+        </div>
+    );
+};
+
+SynonymList.propTypes = {
+    idx: PropTypes.number,
+    expressionState: PropTypes.array,
+    handleCatChange: PropTypes.func,
+};
+
+export default SynonymList;

--- a/training-interface/src/components/Entities/components/index.js
+++ b/training-interface/src/components/Entities/components/index.js
@@ -1,0 +1,6 @@
+export { default } from './EntityForm';
+export { default } from './SynonymInput';
+export { default } from './SynonymList';
+
+
+

--- a/training-interface/src/components/Intents/Intents.js
+++ b/training-interface/src/components/Intents/Intents.js
@@ -48,6 +48,7 @@ class Intents extends Component {
       });
       return getDatas;
   }
+
   handleEdit(intent){
    this.setState({edit: true});
    this.setState({editState: intent});
@@ -93,8 +94,9 @@ class Intents extends Component {
     });
   }
  
-  //When the user clicks edit the corresponding intent object is passed in here
+  
 
+    // Similar to entities, if I was to work more on this there would be a table component to prevent dupe
   generateTable(){
     this.getData()
       .then((response) => { 

--- a/training-interface/src/components/Intents/Intents.js
+++ b/training-interface/src/components/Intents/Intents.js
@@ -9,20 +9,17 @@ import Button from 'react-bootstrap/Button'
 import IntentForm from './components/IntentForm'
 import '../../App.css';
 
-const axios = require('axios').default; 
+const axios = require('axios').default;
 
 class Intents extends Component {
   constructor(props) {
     super(props);
     this.state = {
       intent: '',
-      string: '',
-      obj:null,
-      arrString: null,
-      addExpressions:[],
-      removeList:[],
-      edit : false,
-      editState : null,
+      tableArray: null,
+      removeList: [],
+      edit: false,
+      editState: null,
     };
 
     this.generateTable = this.generateTable.bind(this);
@@ -30,97 +27,97 @@ class Intents extends Component {
     this.handleRemove = this.handleRemove.bind(this);
     this.handleEdit = this.handleEdit.bind(this);
   }
-  
-  componentDidMount(){
+
+  componentDidMount() {
     this.generateTable();
   }
 
-  getData(){
-     var getDatas = axios.get('http://localhost:5000/api/intents')
-      .then((response) => { 
+  getData() {
+    var getDatas = axios.get('http://localhost:5000/api/intents')
+      .then((response) => {
         console.log(response.data);
         return response.data;
       })
       .catch(function (error) {
         console.log(error);
         return error;
-        
+
       });
-      return getDatas;
+    return getDatas;
   }
 
-  handleEdit(intent){
-   this.setState({edit: true});
-   this.setState({editState: intent});
-   console.log('Now state is', this.state.edit)
+  handleEdit(intent) {
+    this.setState({ edit: true });
+    this.setState({ editState: intent });
+    console.log('Now state is', this.state.edit)
   }
 
-  handleCheck(e){
+  handleCheck(e) {
     var inList = false;
     var arr = this.state.removeList;
-    for(var i = 0; i< arr.length; i++){
+    for (var i = 0; i < arr.length; i++) {
       //Remove if unchecked
-      if(arr[i]== e.target.name){
+      if (arr[i] == e.target.name) {
         inList = true;
         arr.splice(i, 1)
         console.log('Removed', e.target.name)
       }
     }
-    if(!inList){
+    if (!inList) {
       arr.push(e.target.name);
       console.log('Added', e.target.name);
     }
-    this.setState({removeList: arr})
+    this.setState({ removeList: arr })
     console.log('Updated', arr)
- }
-
- handleRemove(e){
-  var promiseArr = [];
-  var arr = this.state.removeList;
-  console.log('Trying to remove:', arr);
-
-  arr.forEach(e => {
-    var req = 'http://localhost:5000/api/intents/' + e.toString();
-    console.log('removing', req);
-    promiseArr.push(axios.delete(req))
-  })
-  Promise.all(promiseArr)
-    .then(function (response) {
-      console.log(response);
-      window.location.reload(true);
-    })
-    .catch(function (error) {
-      console.log(error);
-    });
   }
- 
-  
 
-    // Similar to entities, if I was to work more on this there would be a table component to prevent dupe
-  generateTable(){
+  handleRemove(e) {
+    var promiseArr = [];
+    var arr = this.state.removeList;
+    console.log('Trying to remove:', arr);
+
+    arr.forEach(e => {
+      var req = 'http://localhost:5000/api/intents/' + e.toString();
+      console.log('removing', req);
+      promiseArr.push(axios.delete(req))
+    })
+    Promise.all(promiseArr)
+      .then(function (response) {
+        console.log(response);
+        window.location.reload(true);
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  }
+
+
+
+  // Similar to entities, if I was to work more on this there would be a table component to prevent dupe
+  generateTable() {
     this.getData()
-      .then((response) => { 
+      .then((response) => {
         console.log("response", response);
         var x = response;
         var arr = [];
-        
-        for (var i=0; i<x.length; i++) {
+
+        for (var i = 0; i < x.length; i++) {
           var element = (
             <div>
-            <div className="custom-control custom-checkbox">
-              <input type="checkbox" className="custom-control-input" id={x[i]._id} onClick={this.handleCheck} name={x[i].name}></input>
-              <label className="custom-control-label" for={x[i]._id}> {x[i].name} </label>
-              <Button variant="outline-warning" size="sm" style={{align: "right", marginLeft:"10px",lineHeight: "1.1" , borderRadius: "10px"}} 
-                onClick={()=>{this.handleEdit(x[i])}}>
-                + 
+              <div className="custom-control custom-checkbox">
+                <input type="checkbox" className="custom-control-input" id={x[i]._id} onClick={this.handleCheck} name={x[i].name}></input>
+                <label className="custom-control-label" for={x[i]._id}> {x[i].name} </label>
+                <Button variant="outline-warning" size="sm" style={{ align: "right", marginLeft: "10px", lineHeight: "1.1", borderRadius: "10px" }}
+                  onClick={() => { this.handleEdit(x[i]) }}>
+                  +
               </Button>
+              </div>
+
             </div>
-            
-          </div>
           )
           arr.push(element);
         }
-        this.setState({arrString: arr}) 
+        this.setState({ tableArray: arr })
       })
 
       .catch(function (error) {
@@ -128,45 +125,44 @@ class Intents extends Component {
       });
   }
 
-  
+
   //The form information is supposed to see by
   //run 'json-server db.json -w -p 8000' in /server directory
   //go 'http://localhost:8000/intents'
-  render () {
+  render() {
     return (
-    <div>
-      <InputGroup style = {{padding:"20px"}}>
-        <InputGroup.Prepend>
-          <InputGroup.Text id="btnGroupAddon">@</InputGroup.Text>
-        </InputGroup.Prepend>
+      <div>
+        <InputGroup style={{ padding: "20px" }}>
+          <InputGroup.Prepend>
+            <InputGroup.Text id="btnGroupAddon">@</InputGroup.Text>
+          </InputGroup.Prepend>
           <FormControl
             type="text"
             placeholder="Search for an intent"
             aria-label="Input group example"
             aria-describedby="btnGroupAddon"
           />
-      </InputGroup>
+        </InputGroup>
 
-      <Row style = {{padding:"20px"}}>
-        <Col lg={5}>
-          <Container fluid className="tile-glow">
-            <h4> Intents: </h4>
-            <div style ={{height:"70%", overflow:"auto", borderStyle: "solid", borderWeight:"0.1px", borderColor: "#13beb1", padding:"3px"}}>
-              {this.state.arrString}
-            </div>
-            <Button onClick = {this.handleRemove} variant="outline-danger" style={{ float:"right", width:"20%", margin:"30px"}}>Remove</Button>
-          </Container>
-        </Col>
-        
-        <Col lg={7}>
-          <Jumbotron fluid style = {{width:"50%" ,padding:"20px"}}>
-            {/*This intent form is for creating intents*/}
-            
-             <IntentForm edit={this.state.edit} editState={this.state.edit}/>
-          </Jumbotron>
-        </Col>
-      </Row>
-    </div>
+        <Row style={{ padding: "20px" }}>
+          <Col lg={5}>
+            <Container fluid className="tile-glow">
+              <h4> Intents: </h4>
+              <div style={{ height: "70%", overflow: "auto", borderStyle: "solid", borderWeight: "0.1px", borderColor: "#13beb1", padding: "3px" }}>
+                {this.state.tableArray}
+              </div>
+              <Button onClick={this.handleRemove} variant="outline-danger" style={{ float: "right", width: "20%", margin: "30px" }}>Remove</Button>
+            </Container>
+          </Col>
+
+          <Col lg={7}>
+            <Jumbotron fluid style={{ width: "50%", padding: "20px" }}>
+              {/*This intent form is for creating intents*/}
+              <IntentForm edit={this.state.edit} editState={this.state.edit} />
+            </Jumbotron>
+          </Col>
+        </Row>
+      </div>
     )
   }
 }

--- a/training-interface/src/components/Intents/components/IntentInputs.js
+++ b/training-interface/src/components/Intents/components/IntentInputs.js
@@ -5,6 +5,8 @@ import Form from 'react-bootstrap/Form'
 const IntentInputs = ({ idx, expressionState, handleIntentChange }) => {
     const intentId = `exp-${idx}`;
 
+
+
     return (
         <div key={`exp-${idx}`}>
         


### PR DESCRIPTION
Entities are now displayed and editable to the same extent intents are (which I implemented previously).

A dynamic form allows for entities to be added manually with any number of references and associated synonyms. It uses React Hooks to do this effectively. On submitting a new entity the post request is made and on success the page reloads.

This pull also allows the user to remove multiple entities at once, all changes are reflected on the db for those of you using the docker container.